### PR TITLE
Fix newline formatting in env example

### DIFF
--- a/env.example
+++ b/env.example
@@ -37,4 +37,5 @@ NEXT_PUBLIC_DISABLE_AUTH="false"
 # NEXT_PUBLIC_GOOGLE_CLIENT_SECRET=""
 # NEXT_PUBLIC_GOOGLE_REDIRECT_URI=""
 # NEXT_PUBLIC_FIREBASE_VAPID_KEY="" # Para Firebase Cloud Messaging (Web Push)
-\n# Domínios permitidos para desenvolvimento\nALLOWED_DEV_ORIGINS=""
+# Domínios permitidos para desenvolvimento
+ALLOWED_DEV_ORIGINS=""


### PR DESCRIPTION
## Summary
- split the last comment and variable declaration into separate lines in `env.example`

## Testing
- `npm test` *(fails: `scripts/run-tests.sh` not found)*
- `npx jest` *(fails: needs installation)*

------
https://chatgpt.com/codex/tasks/task_e_6854f84846b4832483f1f73cc6a23d0a