### PR TITLE
Implement login flow and patient features

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,17 @@ service cloud.firestore {
     match /users/{userId}/sessions/{sessionId} {
       allow read, write: if request.auth.uid == userId;
     }
+    // Patients collection e subcoleção sessions
+    match /patients/{patientId} {
+      allow read, write: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role in ['admin', 'psychologist'];
+      match /sessions/{sessionId} {
+        allow read, write: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role in ['admin', 'psychologist'];
+      }
+    }
+    // Appointments collection
+    match /appointments/{appointmentId} {
+      allow read, write: if request.auth != null;
+    }
     // Default deny
     match /{document=**} {
       allow read, write: if false;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  if (process.env.NEXT_PUBLIC_DISABLE_AUTH === 'true') {
+    return NextResponse.next();
+  }
+  const loggedIn = req.cookies.get('loggedIn')?.value === 'true';
+  if (!loggedIn) {
+    const loginUrl = new URL('/login', req.url);
+    loginUrl.searchParams.set('redirect', req.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/app/:path*'],
+};

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
+import { ReactNode, useEffect } from 'react';
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_DISABLE_AUTH !== 'true' && !user) {
+      router.push('/login');
+    }
+  }, [user, router]);
+
+  if (process.env.NEXT_PUBLIC_DISABLE_AUTH !== 'true' && !user) return null;
+
+  return <div>{children}</div>;
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,7 @@
+export default function AppHome() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Área Privada</h1>
+    </main>
+  );
+}

--- a/src/app/app/patients/[id]/sessions/page.tsx
+++ b/src/app/app/patients/[id]/sessions/page.tsx
@@ -1,0 +1,12 @@
+import { features } from '@/config/features';
+import { PatientSessions } from '@/features/sessions/PatientSessions';
+
+export default function PatientSessionsPage({ params }: { params: { id: string } }) {
+  if (!features.sessions) return null;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Sessões</h1>
+      <PatientSessions patientId={params.id} />
+    </main>
+  );
+}

--- a/src/app/app/patients/page.tsx
+++ b/src/app/app/patients/page.tsx
@@ -1,0 +1,12 @@
+import { features } from '@/config/features';
+import { PatientList } from '@/features/patients/PatientList';
+
+export default function PatientsPage() {
+  if (!features.patients) return null;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Pacientes</h1>
+      <PatientList />
+    </main>
+  );
+}

--- a/src/app/app/schedule/page.tsx
+++ b/src/app/app/schedule/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/dist/style.css';
+
+export default function SchedulePage() {
+  const [selected, setSelected] = useState<Date | undefined>();
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Agenda</h1>
+      <DayPicker mode="single" selected={selected} onSelect={setSelected} />
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@/styles/globals.css';
 import { PT_Sans, Alegreya } from 'next/font/google';
 import type { ReactNode } from 'react';
+import { AuthProvider } from '@/context/AuthContext';
 
 const ptSans = PT_Sans({ weight: ['400', '700'], subsets: ['latin'], variable: '--font-sans' });
 const alegreya = Alegreya({ weight: ['400', '700'], subsets: ['latin'], variable: '--font-serif' });
@@ -9,8 +10,10 @@ export const metadata = { title: 'Thalamus' };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="pt-br" className={`${ptSans.variable} ${alegreya.variable}`}> 
-      <body className="font-sans bg-background text-foreground">{children}</body>
+    <html lang="pt-br" className={`${ptSans.variable} ${alegreya.variable}`}>
+      <body className="font-sans bg-background text-foreground">
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/components/Button';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const onSubmit = async (data: FormData) => {
+    await signInWithEmailAndPassword(auth, data.email, data.password);
+    document.cookie = 'loggedIn=true; path=/';
+    router.push(params.get('redirect') || '/app');
+  };
+
+  return (
+    <main className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <input
+            type="email"
+            placeholder="Email"
+            {...register('email')}
+            className="w-full p-2 border rounded"
+          />
+          {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+        </div>
+        <div>
+          <input
+            type="password"
+            placeholder="Senha"
+            {...register('password')}
+            className="w-full p-2 border rounded"
+          />
+          {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+        </div>
+        <Button type="submit" className="w-full">
+          Entrar
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,4 +1,7 @@
 export const features = {
   dashboard: true,
   aiAssistant: false,
+  patients: true,
+  sessions: true,
+  schedule: true,
 };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { auth, db } from '@/lib/firebase';
+
+export interface UserInfo {
+  uid: string;
+  email: string | null;
+  role?: string;
+}
+
+interface AuthContextValue {
+  user: UserInfo | null;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  logout: async () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (firebaseUser) {
+        const snap = await getDoc(doc(db, 'users', firebaseUser.uid));
+        const role = snap.exists() ? (snap.data() as any).role : undefined;
+        setUser({ uid: firebaseUser.uid, email: firebaseUser.email, role });
+      } else {
+        setUser(null);
+      }
+    });
+    return unsub;
+  }, []);
+
+  const logout = async () => {
+    await signOut(auth);
+    document.cookie = 'loggedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  };
+
+  return <AuthContext.Provider value={{ user, logout }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/features/patients/PatientList.tsx
+++ b/src/features/patients/PatientList.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { collection, getDocs } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebase';
+
+interface Patient {
+  id: string;
+  name: string;
+  contact?: string;
+}
+
+export function PatientList() {
+  const [patients, setPatients] = useState<Patient[]>([]);
+
+  useEffect(() => {
+    getDocs(collection(db, 'patients')).then((snap) => {
+      setPatients(
+        snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as Omit<Patient, 'id'>) }))
+      );
+    });
+  }, []);
+
+  return (
+    <ul className="space-y-2">
+      {patients.map((p) => (
+        <li key={p.id} className="p-2 border rounded">
+          {p.name}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/sessions/PatientSessions.tsx
+++ b/src/features/sessions/PatientSessions.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { collection, getDocs } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebase';
+
+interface Session {
+  id: string;
+  date: string;
+}
+
+export function PatientSessions({ patientId }: { patientId: string }) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+
+  useEffect(() => {
+    getDocs(collection(db, 'patients', patientId, 'sessions')).then((snap) => {
+      setSessions(snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Session, 'id'>) })));
+    });
+  }, [patientId]);
+
+  return (
+    <ul className="space-y-2">
+      {sessions.map((s) => (
+        <li key={s.id} className="p-2 border rounded">
+          {s.date}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@/app/login/page';
+
+jest.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  auth: {},
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+describe('LoginPage', () => {
+  it('renderiza campos de login', () => {
+    render(<LoginPage />);
+    expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/senha/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Firebase-based AuthContext and wrap app with provider
- create login page with form validation
- protect /app routes with middleware and client layout
- add schedule page using react-day-picker
- list patients and patient sessions with Firestore data
- extend feature flags and Firestore rules
- test home and login pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685512ae0b34832490fae3fe61e2a47a