### PR TITLE
Implement encrypted records and basic dashboard

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,10 +25,17 @@ service cloud.firestore {
       match /sessions/{sessionId} {
         allow read, write: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role in ['admin', 'psychologist'];
       }
+      match /records/{recordId} {
+        allow read, write: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role in ['admin', 'psychologist'];
+      }
     }
     // Appointments collection
     match /appointments/{appointmentId} {
       allow read, write: if request.auth != null;
+    }
+    // Waiting list
+    match /waitingList/{itemId} {
+      allow read, write: if request.auth != null && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role in ['admin', 'psychologist'];
     }
     // Default deny
     match /{document=**} {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import './jest.polyfills';

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "firebase-admin": "^13.4.0",
         "genkit": "^1.8.0",
         "googleapis": "^130.0.0",
+        "idb-keyval": "^6.2.2",
         "lucide-react": "^0.475.0",
         "nanoid": "^5.0.7",
         "next": "^15.3.4",
@@ -83,7 +84,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "firebase-tools": "^14.6.0",
         "genkit-cli": "^1.8.0",
-        "husky": "^9.1.7",
+        "husky": "^9.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
@@ -16227,6 +16228,12 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "firebase-admin": "^13.4.0",
     "genkit": "^1.8.0",
     "googleapis": "^130.0.0",
+    "idb-keyval": "^6.2.2",
     "lucide-react": "^0.475.0",
     "nanoid": "^5.0.7",
     "next": "^15.3.4",

--- a/src/app/app/patients/[id]/records/new/page.tsx
+++ b/src/app/app/patients/[id]/records/new/page.tsx
@@ -1,0 +1,12 @@
+import { features } from '@/config/features';
+import { RecordForm } from '@/features/records/RecordForm';
+
+export default function NewRecordPage({ params }: { params: { id: string } }) {
+  if (!features.records) return null;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Novo Prontu\xE1rio</h1>
+      <RecordForm patientId={params.id} />
+    </main>
+  );
+}

--- a/src/app/app/patients/[id]/records/page.tsx
+++ b/src/app/app/patients/[id]/records/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import { features } from '@/config/features';
+import { RecordList } from '@/features/records/RecordList';
+
+export default function PatientRecordsPage({ params }: { params: { id: string } }) {
+  if (!features.records) return null;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Prontu\xE1rios</h1>
+      <Link href={`/app/patients/${params.id}/records/new`} className="text-blue-600">Novo registro</Link>
+      <RecordList patientId={params.id} />
+    </main>
+  );
+}

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -3,5 +3,6 @@ export const features = {
   aiAssistant: false,
   patients: true,
   sessions: true,
+  records: true,
   schedule: true,
 };

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -1,6 +1,49 @@
+import { useEffect, useState } from 'react';
 import { features } from '@/config/features';
+import { db } from '@/lib/firebase';
+import { collection, getDocs, collectionGroup } from 'firebase/firestore';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+
+interface Metrics {
+  patients: number;
+  sessions: number;
+}
 
 export function Dashboard() {
   if (!features.dashboard) return null;
-  return <section className="mt-4">Dashboard habilitado</section>;
+  const [metrics, setMetrics] = useState<Metrics>({ patients: 0, sessions: 0 });
+
+  useEffect(() => {
+    Promise.all([
+      getDocs(collection(db, 'patients')),
+      getDocs(collectionGroup(db, 'sessions')),
+    ]).then(([pSnap, sSnap]) => {
+      setMetrics({ patients: pSnap.size, sessions: sSnap.size });
+    });
+  }, []);
+
+  const data = [
+    { name: 'Pacientes', value: metrics.patients },
+    { name: 'Sessões', value: metrics.sessions },
+  ];
+
+  return (
+    <section className="mt-4">
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Bar dataKey="value" fill="#8884d8" />
+        </BarChart>
+      </ResponsiveContainer>
+    </section>
+  );
 }

--- a/src/features/patients/PatientList.tsx
+++ b/src/features/patients/PatientList.tsx
@@ -24,7 +24,9 @@ export function PatientList() {
     <ul className="space-y-2">
       {patients.map((p) => (
         <li key={p.id} className="p-2 border rounded">
-          {p.name}
+          <a href={`/app/patients/${p.id}/records`} className="text-blue-600">
+            {p.name}
+          </a>
         </li>
       ))}
     </ul>

--- a/src/features/records/RecordForm.tsx
+++ b/src/features/records/RecordForm.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { db } from '@/lib/firebase';
+import { encryptText } from '@/lib/encryption';
+import { Button } from '@/components/Button';
+
+const schema = z.object({
+  notes: z.string().min(1),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function RecordForm({ patientId }: { patientId: string }) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    const enc = await encryptText(data.notes);
+    await addDoc(collection(db, 'patients', patientId, 'records'), {
+      encrypted: enc.data,
+      iv: enc.iv,
+      createdAt: serverTimestamp(),
+    });
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <textarea
+        {...register('notes')}
+        className="w-full p-2 border rounded"
+        rows={6}
+        placeholder="Anota\xE7\xF5es"
+      />
+      {errors.notes && <p className="text-red-500 text-sm">{errors.notes.message}</p>}
+      <Button type="submit">Salvar</Button>
+    </form>
+  );
+}

--- a/src/features/records/RecordList.tsx
+++ b/src/features/records/RecordList.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebase';
+import { decryptText } from '@/lib/encryption';
+
+interface RecordData {
+  id: string;
+  notes: string;
+}
+
+export function RecordList({ patientId }: { patientId: string }) {
+  const [records, setRecords] = useState<RecordData[]>([]);
+
+  useEffect(() => {
+    getDocs(query(collection(db, 'patients', patientId, 'records'), orderBy('createdAt', 'desc'))).then(async (snap) => {
+      const items = await Promise.all(
+        snap.docs.map(async (d) => {
+          const { encrypted, iv } = d.data() as any;
+          const notes = await decryptText(encrypted, iv);
+          return { id: d.id, notes };
+        })
+      );
+      setRecords(items);
+    });
+  }, [patientId]);
+
+  return (
+    <ul className="space-y-2">
+      {records.map((r) => (
+        <li key={r.id} className="p-2 border rounded">
+          {r.notes}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -1,0 +1,38 @@
+export async function getKey(): Promise<CryptoKey> {
+  const { get, set } = await import('idb-keyval');
+  const KEY_NAME = 'encryptionKey';
+  let stored = await get(KEY_NAME);
+  if (stored) {
+    return crypto.subtle.importKey('raw', stored, 'AES-GCM', true, [
+      'encrypt',
+      'decrypt',
+    ]);
+  }
+  const key = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  );
+  const exported = await crypto.subtle.exportKey('raw', key);
+  await set(KEY_NAME, exported);
+  return key;
+}
+
+export async function encryptText(plain: string) {
+  const key = await getKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plain);
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+  return {
+    data: btoa(String.fromCharCode(...new Uint8Array(ct))),
+    iv: btoa(String.fromCharCode(...iv)),
+  };
+}
+
+export async function decryptText(data: string, iv: string) {
+  const key = await getKey();
+  const buf = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
+  const ivBuf = Uint8Array.from(atob(iv), (c) => c.charCodeAt(0));
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: ivBuf }, key, buf);
+  return new TextDecoder().decode(plain);
+}

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,17 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { addDays, startOfDay } from 'date-fns';
+import { db } from './firebase';
+
+export async function suggestNextSlot(): Promise<string | null> {
+  const today = startOfDay(new Date());
+  for (let i = 0; i < 30; i++) {
+    const date = addDays(today, i);
+    const iso = date.toISOString().slice(0, 10);
+    const q = query(collection(db, 'appointments'), where('date', '==', iso));
+    const snap = await getDocs(q);
+    if (snap.empty) {
+      return `${iso}T09:00`;
+    }
+  }
+  return null;
+}

--- a/src/lib/waitingList/addToWaitingList.ts
+++ b/src/lib/waitingList/addToWaitingList.ts
@@ -1,0 +1,10 @@
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function addToWaitingList(patientId: string, priority = 1) {
+  await addDoc(collection(db, 'waitingList'), {
+    patientId,
+    priority,
+    addedAt: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
## Summary
- store and retrieve AES key via IndexedDB
- encrypt/decrypt patient notes when saving records
- add patient records pages and list
- show metrics with Recharts on dashboard
- include waiting list utilities and slot suggestion helper
- allow new collections in Firestore rules
- enable polyfills in Jest setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685516259b6883249b15638278ffe9ed