### PR TITLE
Add AI session editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Plataforma web para gestão de clínicas de psicologia, com agenda integrada, pr
 - **Tailwind CSS**
 - **Firebase**: Firestore, Cloud Functions, Cloud Messaging, Storage e Hosting
 - **Genkit** + Google AI para funcionalidades de inteligência artificial
+- **Editor de Sessões com IA** para analisar notas, sugerir templates e salvar preferências
 - **Jest** e Testing Library para testes automatizados
 
 ## Configuração do Ambiente

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,9 @@ service cloud.firestore {
     match /users/{userId} {
       allow read, update: if request.auth.uid == userId;
       allow create: if request.auth != null;
+      match /preferences/{prefId} {
+        allow read, write: if request.auth.uid == userId;
+      }
     }
     // Assessments collection - psicólogos e admins podem ler e escrever
     match /assessments/{assessmentId} {

--- a/src/ai/flows.ts
+++ b/src/ai/flows.ts
@@ -1,0 +1,42 @@
+import { genkit } from 'genkit';
+import { googleAI, gemini } from '@genkit-ai/googleai';
+import { z } from 'zod';
+
+const ai = genkit({
+  plugins: [googleAI()],
+  model: gemini('gemini-1.5-flash'),
+});
+
+export const analyzeSession = ai.defineFlow(
+  {
+    name: 'analyzeSession',
+    inputSchema: z.object({ text: z.string() }),
+    outputSchema: z.object({
+      keywords: z.array(z.string()),
+      themes: z.array(z.string()),
+    }),
+  },
+  async ({ text }) => {
+    const { text: result } = await ai.generate({
+      prompt:
+        'Analise o texto a seguir e extraia palavras-chave e possiveis temas de terapia em JSON: ' +
+        text,
+    });
+    return JSON.parse(result);
+  },
+);
+
+export const suggestTemplate = ai.defineFlow(
+  {
+    name: 'suggestTemplate',
+    inputSchema: z.object({ topic: z.string() }),
+    outputSchema: z.object({ template: z.string() }),
+  },
+  async ({ topic }) => {
+    const { text: tpl } = await ai.generate({
+      prompt: 'Sugira um template de sessao para o tema: ' + topic,
+    });
+    return { template: tpl };
+  },
+);
+

--- a/src/app/api/ai/session-insights/route.ts
+++ b/src/app/api/ai/session-insights/route.ts
@@ -1,0 +1,6 @@
+import { analyzeSession } from '@/ai/flows';
+import appRoute from '@genkit-ai/next';
+
+export const POST = appRoute(analyzeSession);
+export const dynamic = 'force-dynamic';
+

--- a/src/app/api/ai/suggest-template/route.ts
+++ b/src/app/api/ai/suggest-template/route.ts
@@ -1,0 +1,6 @@
+import { suggestTemplate } from '@/ai/flows';
+import appRoute from '@genkit-ai/next';
+
+export const POST = appRoute(suggestTemplate);
+export const dynamic = 'force-dynamic';
+

--- a/src/app/app/patients/[id]/sessions/new/page.tsx
+++ b/src/app/app/patients/[id]/sessions/new/page.tsx
@@ -1,0 +1,13 @@
+import { features } from '@/config/features';
+import { SessionEditor } from '@/features/sessions/SessionEditor';
+
+export default function NewSessionPage({ params }: { params: { id: string } }) {
+  if (!features.sessions) return null;
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Nova Sess\xE3o</h1>
+      <SessionEditor patientId={params.id} />
+    </main>
+  );
+}
+

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,6 +1,6 @@
 export const features = {
   dashboard: true,
-  aiAssistant: false,
+  aiAssistant: true,
   patients: true,
   sessions: true,
   records: true,

--- a/src/features/ai/SessionInsights.tsx
+++ b/src/features/ai/SessionInsights.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useState } from 'react';
+import { runFlow } from '@genkit-ai/next/client';
+import { analyzeSession } from '@/ai/flows';
+import { Button } from '@/components/Button';
+
+interface Insights {
+  keywords: string[];
+  themes: string[];
+}
+
+export function SessionInsights() {
+  const [text, setText] = useState('');
+  const [insights, setInsights] = useState<Insights | null>(null);
+
+  const handleAnalyze = async () => {
+    const result = await runFlow<typeof analyzeSession>({
+      url: '/api/ai/session-insights',
+      input: { text },
+    });
+    setInsights(result);
+  };
+
+  return (
+    <div className="space-y-4">
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className="w-full p-2 border rounded"
+        rows={4}
+        placeholder="Anota\xE7\xF5es da sess\xE3o"
+      />
+      <Button type="button" onClick={handleAnalyze} className="block">
+        Gerar Insights
+      </Button>
+      {insights && (
+        <div className="space-y-2">
+          <div>
+            <h3 className="font-bold">Palavras-chave</h3>
+            <ul className="list-disc ml-6">
+              {insights.keywords.map((k) => (
+                <li key={k}>{k}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-bold">Temas Sugeridos</h3>
+            <ul className="list-disc ml-6">
+              {insights.themes.map((t) => (
+                <li key={t}>{t}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/features/sessions/SessionEditor.tsx
+++ b/src/features/sessions/SessionEditor.tsx
@@ -1,0 +1,129 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { runFlow } from '@genkit-ai/next/client';
+import { suggestTemplate } from '@/ai/flows';
+import { useAuth } from '@/context/AuthContext';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { Button } from '@/components/Button';
+
+interface Block {
+  id: string;
+  title: string;
+  text: string;
+  hidden: boolean;
+}
+
+const defaultBlocks: Block[] = [
+  { id: 'objective', title: 'Objetivo', text: '', hidden: false },
+  { id: 'intervention', title: 'Interven\xE7\xE3o', text: '', hidden: false },
+  { id: 'response', title: 'Resposta', text: '', hidden: false },
+  { id: 'plan', title: 'Plano de A\xE7\xE3o', text: '', hidden: false },
+];
+
+export function SessionEditor({ patientId }: { patientId: string }) {
+  const { user } = useAuth();
+  const [blocks, setBlocks] = useState<Block[]>(defaultBlocks);
+  const [dragId, setDragId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    const ref = doc(db, 'users', user.uid, 'preferences', 'sessionEditor');
+    getDoc(ref).then((snap) => {
+      if (snap.exists()) {
+        const data = snap.data() as any;
+        setBlocks((prev) =>
+          prev.map((b) => ({ ...b, hidden: data.hidden?.includes(b.id) ?? false }))
+        );
+      }
+    });
+  }, [user]);
+
+  const savePrefs = async () => {
+    if (!user) return;
+    const ref = doc(db, 'users', user.uid, 'preferences', 'sessionEditor');
+    await setDoc(
+      ref,
+      {
+        hidden: blocks.filter((b) => b.hidden).map((b) => b.id),
+      },
+      { merge: true },
+    );
+  };
+
+  const handleDragStart = (id: string) => () => setDragId(id);
+  const handleDrop = (id: string) => () => {
+    if (!dragId) return;
+    setBlocks((bl) => {
+      const from = bl.findIndex((b) => b.id === dragId);
+      const to = bl.findIndex((b) => b.id === id);
+      const arr = [...bl];
+      const [moved] = arr.splice(from, 1);
+      arr.splice(to, 0, moved);
+      return arr;
+    });
+    setDragId(null);
+  };
+
+  const toggleBlock = (id: string) => {
+    setBlocks((bl) => bl.map((b) => (b.id === id ? { ...b, hidden: !b.hidden } : b)));
+  };
+
+  const autofill = async () => {
+    const res = await runFlow<typeof suggestTemplate>({
+      url: '/api/ai/suggest-template',
+      input: { topic: 'geral' },
+    });
+    setBlocks((bl) => bl.map((b) => ({ ...b, text: res.template })));
+  };
+
+  return (
+    <div className="flex">
+      <div className="flex-1 space-y-4">
+        {blocks.map(
+          (block) =>
+            !block.hidden && (
+              <div
+                key={block.id}
+                draggable
+                onDragStart={handleDragStart(block.id)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={handleDrop(block.id)}
+                className="border rounded p-2"
+              >
+                <div className="flex justify-between items-center">
+                  <h3 className="font-bold">{block.title}</h3>
+                  <button type="button" onClick={() => toggleBlock(block.id)}>
+                    Ocultar
+                  </button>
+                </div>
+                <textarea
+                  value={block.text}
+                  onChange={(e) =>
+                    setBlocks((bl) =>
+                      bl.map((b) => (b.id === block.id ? { ...b, text: e.target.value } : b))
+                    )
+                  }
+                  className="w-full p-2 border rounded mt-2"
+                  rows={4}
+                />
+              </div>
+            ),
+        )}
+      </div>
+      <div className="w-60 ml-4 space-y-2">
+        <h3 className="font-bold">Mini-Assistente</h3>
+        <Button type="button" onClick={autofill} className="w-full">
+          Sugerir Template
+        </Button>
+        <Button type="button" onClick={savePrefs} className="w-full">
+          Salvar Prefer\xEAncias
+        </Button>
+        <p className="text-sm text-muted-foreground">
+          Arraste os blocos para reorganizar ou clique em ocultar.
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/tests/sessionEditor.test.tsx
+++ b/tests/sessionEditor.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { SessionEditor } from '@/features/sessions/SessionEditor';
+
+jest.mock('@genkit-ai/next/client', () => ({
+  runFlow: jest.fn().mockResolvedValue({ template: 'tpl' }),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  doc: () => ({}),
+  getDoc: jest.fn().mockResolvedValue({ exists: () => false }),
+  setDoc: jest.fn(),
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  db: {},
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: '1', email: 'a' } }),
+}));
+
+describe('SessionEditor', () => {
+  it('exibe blocos padrao', () => {
+    render(<SessionEditor patientId="p1" />);
+    expect(screen.getByText('Objetivo')).toBeInTheDocument();
+    expect(screen.getByText('Interven\xE7\xE3o')).toBeInTheDocument();
+    expect(screen.getByText('Resposta')).toBeInTheDocument();
+    expect(screen.getByText('Plano de A\xE7\xE3o')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- enable AI Assistant feature
- allow users to save preferences in Firestore
- create Genkit flows for session insights and template suggestions
- expose API routes for Genkit flows
- add interactive SessionEditor and SessionInsights components
- document new AI editor feature
- add session editor test

## Testing
- `npm run typecheck` *(fails: jest.polyfills.ts TS2741)*
- `npm run lint` *(fails: Cannot find module './eslint-rules')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551810501083249bcc1dbf3b457a3c