### PR TITLE
Improve tests with Firestore emulator

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,27 @@
 module.exports = {
-  testEnvironment: 'jsdom',
-  transform: {
-    '^.+\\.(ts|tsx)$': 'babel-jest',
-  },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  roots: ['<rootDir>/src', '<rootDir>/tests'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
+  projects: [
+    {
+      displayName: 'client',
+      testEnvironment: 'jsdom',
+      transform: {
+        '^.+\\.(ts|tsx)$': 'babel-jest',
+      },
+      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+      roots: ['<rootDir>/src', '<rootDir>/tests'],
+      setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+      moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+      },
+      testMatch: ['**/*.test.ts?(x)'],
+      testPathIgnorePatterns: ['<rootDir>/tests/firestore.rules.test.ts'],
+    },
+    {
+      displayName: 'firestore',
+      testEnvironment: 'node',
+      transform: {
+        '^.+\\.(ts|tsx)$': 'ts-jest',
+      },
+      testMatch: ['<rootDir>/tests/firestore.rules.test.ts'],
+    },
+  ],
 };

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx jest
+npx jest --selectProjects client

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -1,0 +1,31 @@
+import { initializeTestEnvironment, RulesTestEnvironment, assertSucceeds, assertFails } from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { setDoc, getDoc, doc } from 'firebase/firestore';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-project',
+    firestore: {
+      rules: readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+test('usuário não autenticado não pode escrever em users', async () => {
+  const context = testEnv.unauthenticatedContext();
+  const ref = doc(context.firestore(), 'users/u1');
+  await assertFails(setDoc(ref, { nome: 'Ana' }));
+});
+
+test('usuário autenticado lê seu próprio perfil', async () => {
+  const context = testEnv.authenticatedContext('u1');
+  const ref = doc(context.firestore(), 'users/u1');
+  await assertSucceeds(setDoc(ref, { role: 'psychologist' }));
+  await assertSucceeds(getDoc(ref));
+});

--- a/tests/recordForm.test.tsx
+++ b/tests/recordForm.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecordForm } from '@/features/records/RecordForm';
+
+jest.mock('firebase/firestore', () => ({
+  collection: () => ({}),
+  addDoc: jest.fn(),
+  serverTimestamp: jest.fn(),
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  db: {},
+}));
+
+jest.mock('@/lib/encryption', () => ({
+  encryptText: async (t: string) => ({ data: t, iv: 'iv' }),
+}));
+
+jest.mock('@/lib/offlineRecords', () => ({
+  addPendingRecord: jest.fn(),
+  syncPendingRecords: jest.fn(),
+}));
+
+describe('RecordForm', () => {
+  it('mostra erro quando notas vazias', async () => {
+    render(<RecordForm patientId="p1" />);
+    await userEvent.click(screen.getByRole('button', { name: /salvar/i }));
+    expect(
+      await screen.findByText(/must contain at least 1 character/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- support multi-project jest config
- run default tests only on client code
- add Firestore security rules test
- cover RecordForm validation

## Testing
- `npm test`
- `npm run test:rules`
- `npm run build` *(fails: next/font requires SWC because of custom babel config)*

------
https://chatgpt.com/codex/tasks/task_e_68551a7c52b08324bd1f517079eb3380